### PR TITLE
Fix initial scroll position

### DIFF
--- a/CalendarDateRangePickerViewController/Classes/CalendarDateRangePickerViewController.swift
+++ b/CalendarDateRangePickerViewController/Classes/CalendarDateRangePickerViewController.swift
@@ -126,8 +126,10 @@ import UIKit
 
     public override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
-        if selectedStartDate != nil || scrollToDate != nil {
-            self.scrollToSelection()
+        DispatchQueue.main.async { [weak self] in
+            if self?.selectedStartDate != nil || self?.scrollToDate != nil {
+                self?.scrollToSelection()
+            }
         }
     }
 }
@@ -356,13 +358,13 @@ extension CalendarDateRangePickerViewController {
             if let date = self.selectedStartDate {
                 let calendar = Calendar.current
                 let yearDiff = calendar.component(.year, from: date) - calendar.component(.year, from: minimumDate)
-                let selectedMonth = calendar.component(.month, from: date) + (yearDiff * 12) - (calendar.component(.month, from: Date()))
+                let selectedMonth = calendar.component(.month, from: date) + (yearDiff * 12) - (calendar.component(.month, from: minimumDate))
                 uCollectionView.scrollToItem(at: IndexPath(row: calendar.component(.day, from: date), section: selectedMonth), at: UICollectionView.ScrollPosition.centeredVertically, animated: false)
             }
             else if let date = self.scrollToDate {
                 let calendar = Calendar.current
                 let yearDiff = calendar.component(.year, from: date) - calendar.component(.year, from: minimumDate)
-                let selectedMonth = calendar.component(.month, from: date) + (yearDiff * 12) - (calendar.component(.month, from: Date()))
+                let selectedMonth = calendar.component(.month, from: date) + (yearDiff * 12) - (calendar.component(.month, from: minimumDate))
                 uCollectionView.scrollToItem(at: IndexPath(row: calendar.component(.day, from: date), section: selectedMonth), at: UICollectionView.ScrollPosition.centeredVertically, animated: false)
             }
         }


### PR DESCRIPTION
Nice pod! It saved me a lot of work!

There were just 2 minor issues with scrolling to the selected date that I fixed:
- `scrollToSelection` should be dispatched so the collection view has time to load its data first
- The offset should be calculated based on the specified `minimumDate` (not the current date which is just its default value)