### PR TITLE
Fix month label generation in Polish

### DIFF
--- a/Example/Pods/CalendarDateRangePicker/CalendarDateRangePickerViewController/Classes/CalendarDateRangePickerViewController.swift
+++ b/Example/Pods/CalendarDateRangePicker/CalendarDateRangePickerViewController/Classes/CalendarDateRangePickerViewController.swift
@@ -381,7 +381,7 @@ extension CalendarDateRangePickerViewController {
 
     @objc func getMonthLabel(date: Date) -> String {
         let dateFormatter = DateFormatter()
-        dateFormatter.dateFormat = "MMMM yyyy"
+        dateFormatter.setLocalizedDateFormatFromTemplate("MMMM yyyy")
         if let locale = locale {dateFormatter.locale = locale}
         return dateFormatter.string(from: date).capitalized
     }
@@ -403,7 +403,7 @@ extension CalendarDateRangePickerViewController {
             return "E"
         }
         let dateFormatter = DateFormatter()
-        dateFormatter.dateFormat = "EEEEE"
+        dateFormatter.setLocalizedDateFormatFromTemplate("EEEEE")
         if let locale = locale {dateFormatter.locale = locale}
         return dateFormatter.string(from: date!).uppercased()
     }


### PR DESCRIPTION
The month labels in polish are not correct. Changed dateFormat to localizedDateFormatFromTemplate according to Apples recommendation

https://developer.apple.com/forums/thread/702587

Fixes issue https://github.com/Ljuka/CalendarDateRangePicker/issues/13